### PR TITLE
fix for "__trim__ Function not available from Envjs.setCookie Method"

### DIFF
--- a/src/main/resources/tv/bodil/testlol/js/env.rhino.js
+++ b/src/main/resources/tv/bodil/testlol/js/env.rhino.js
@@ -268,6 +268,10 @@ Envjs.loadLink = function(node, href) {
 
 (function(){
 
+function __trim__( str ){
+    return (str || "").replace( /^\s+|\s+$/g, "" );
+}
+
 
 /*
  *  cookie handling


### PR DESCRIPTION
http://envjs.lighthouseapp.com/projects/21590/tickets/178-__trim__-function-not-available-from-envjssetcookie-method
